### PR TITLE
Fixed map vertical overflow

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -96,7 +96,7 @@ function App() {
       <Header/>
       <Map
         {...viewState}
-        style={{width: "100vw", height: "100vh"}}
+        style={{width: "100vw", height: "100%"}}
         mapStyle="mapbox://styles/sonnynomnom/cl140ktw8000c15qyyzbezy1u"
         mapboxAccessToken={process.env.REACT_APP_MAPBOX}
         onMove={evt => setViewState(evt.viewState)}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,3 +1,8 @@
+.App {
+  height: 100vh;
+  overflow: hidden;
+}
+
 .popup {
   position: absolute;
   top: 15px;


### PR DESCRIPTION
The map was previously set to `100vh`, meaning 100% the viewport height. But it was pushed down a bit by the header: its top wasn't aligned to the viewport's top.

```plaintext
            ------
           |          ---
           |         |
           | header --
           |         |
           |          ---
           |          ---
           |         |
viewport --|         |
           |         |
           |         |
           |    map --
           |         |
           |         |
           |         |
           |          ---
            ------
```

This change sets the container `.App` component to have `100vh` and the map to have `100%` height. The map will therefore take up 100% of the `.App` after the header.