### PR TITLE
Fixed responsive filters position with calc and vh

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -165,8 +165,7 @@ input::placeholder, textarea::placeholder {
 
 @media only screen and (max-width: 960px) {
   .filters {
-    position: absolute;
-    bottom: 320px;
+    bottom: calc(45vh + 90px);
   }
 }
 


### PR DESCRIPTION
The `.popup` box has its height set by two things:

* `height: 45vh` (45% of viewport height)
* `padding: 40px` adds to that height
    * (the `box-sizing` CSS property can stop padding from adding to height)

Therefore, setting `bottom: calc(45vh + 90px)` puts the `.filters` div 10px higher than the popup.

The second `position: absolute` line was also redundant. 