### PR TITLE
Fix: align filters to bottom on mobile when no place is selected

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -241,7 +241,7 @@ function App() {
           />
         )} */}
         {/* Filters */}
-        <div className="filters">
+        <div className={currentPlaceId ? "filters active" : "filters"}>
           <button className="filter all">All</button>
           <button className="filter public">🌎 Public</button>
           <button className="filter restaurant">🍕 Food</button>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -164,7 +164,7 @@ input::placeholder, textarea::placeholder {
 }
 
 @media only screen and (max-width: 960px) {
-  .filters {
+  .filters.active {
     bottom: calc(45vh + 90px);
   }
 }


### PR DESCRIPTION
Filters should only have the bigger CSS `bottom: ...` when there is a current place selected.